### PR TITLE
Update the restart schedules to include DW20 1.18

### DIFF
--- a/content/server info/wipes.md
+++ b/content/server info/wipes.md
@@ -17,45 +17,45 @@ All times listed are in Eastern Standard Time (EST). This is the same as GMT-5. 
 
 ## Restart Times (EST)
 
+#### 1.18 and Vanilla Servers
+| Server Name        | Restart Time   | Restart Time |
+| :----------------: | :------------: |:------------:|
+| Direwolf20 1.18    | 12:00 AM/PM    |  6:00 AM/PM  |
+| Vanilla            | 12:00 AM/PM    |              |
 
-####  1.16 and Vanilla Pack Restarts
+####  1.16 Servers
 
-|        Server Name        | Restart Time   | Restart Time   |
-|:-------------------------:| :------------: | :------------: |
-|     ATM6: To The Sky      | 4:30 AM/PM     | 10:30 AM/PM    |
-|      Direwolf20 1.16      | 2:30 AM/PM     | 8:30 AM/PM     |
-|         Endeavour         | 3:30 AM/PM     | 9:30 AM/PM     |
-|       Enigmatica 6        | 6:00 AM/PM     | 12 AM/PM       |
-|   Enigmatica 6: Expert    | 1:30 AM/PM     | 7:30 AM/PM     |
-|      FTB OceanBlock       | 6:30 AM/PM     | 11:30 AM/PM    |
-| FTB Ultimate Reloaded: AE | 1:30 AM/PM     | 7:30 AM/PM     |
-|          Vanilla          | 12:00 AM/PM    |                |
+| Server Name                 | Restart Time   | Restart Time   |
+| :-------------------------: | :------------: | :------------: |
+| ATM6: To The Sky            | 4:30 AM/PM     | 10:30 AM/PM    |
+| Enigmatica 6: Expert        | 1:30 AM/PM     | 7:30 AM/PM     |
+| FTB OceanBlock              | 6:30 AM/PM     | 11:30 AM/PM    |
 
 #### 1.12 Servers
 
 | Server Name        | Restart Time     | Restart Time     | Restart Time     |
 | :----------------: | :--------------: | :--------------: | :--------------: |
 | FTB Revelation     | 12 AM            | 8 AM             | 4 PM             |
-| FTB Skyfactory 3   | 2 AM             | 10 AM            | 6 PM             |
 | FTB Stoneblock 2   | 12 AM            | 8 AM             | 4 PM             |
 | MC Eternal         | 2 AM             | 10 AM            | 6 PM             |
 | Project Ozone 3    | 3 AM             | 11 AM            | 7 PM             |
 | Skyfactory 4       | 3 AM             | 11 AM            | 7 PM             |
 
 ##  Wipes 
+These wipes only happen on 1.12 and 1.16 servers.
 
-| World Name      | Wipe Date     | Wipe Date |
-| :--------:      | :-------:     |:---------:|
-| The End         | Every Restart |    N/A    |
-| The Nether      | 14            |    28     |
-| Twilight Forest | 14            |    28     |
-| Deep Dark       | 28            |    N/A    |
-| Beneath         | 28            |    N/A    |
-| Mining World    | 28            |    N/A    |
-| Lost Cities     | 28            |    N/A    |
-| BetweenLands    | 28            |    N/A    |
-| Undergarden     | 28            |    N/A    |
-| Hunting Dim     | 28            |    N/A    |
+| World Name      | Wipe Date     | Wipe Date   |
+| :--------:      | :-------:     | :---------: |
+| The End         | Every Restart | N/A         |
+| The Nether      | 14            | 28          |
+| Twilight Forest | 14            | 28          |
+| Deep Dark       | 28            | N/A         |
+| Beneath         | 28            | N/A         |
+| Mining World    | 28            | N/A         |
+| Lost Cities     | 28            | N/A         |
+| BetweenLands    | 28            | N/A         |
+| Undergarden     | 28            | N/A         |
+| Hunting Dim     | 28            | N/A         |
 
 Compact Machines, Spectre, and the Void dimensions are not wiped. **The overworld and space are only wiped if there are heavy lag issues that the staff team cannot fix.**
 

--- a/content/server info/wipes.md
+++ b/content/server info/wipes.md
@@ -7,12 +7,16 @@ tags: ["modded Minecraft commands", "Modded Minecraft", "Minecraft Network", "Sh
 aliases: ["/home/wipes/", "/restarts"]
 -----------------------------
 
-Servers restart every once in a while to reduce lag. This does not mean that a restart will fix all kinds of lag so, please, **do not** as staff to restart a server due to lag. **Restarts are NOT wipes**, they are just a scheduled reboot to the server. 
+Servers restart every once in a while to reduce lag. This does not mean that a restart will fix all kinds of lag. So, 
+please, **do not** ask staff to restart a server due to lag. **Restarts are NOT wipes**, they are just a scheduled reboot to the server. 
 
 *Ground items are cleared every 20 minutes (XX:10, XX:30, XX:50). There is a 1 minute warning before a clear.*
 
 {{% notice note %}}
-All times listed are in Eastern Standard Time (EST). This is the same as GMT-5. Wipes will happen during the nightly restart. Restarts happen both in the AM and in the PM.
+All times listed are in Eastern Standard Time (EST). This is the same as GMT-5. Wipes will happen during the nightly 
+restart. Restarts happen both in the AM and in the PM. The times might appear to be an hour off if you're currently in 
+Daylight 
+Savings Time (DST).
 {{% /notice %}}
 
 ## Restart Times (EST)


### PR DESCRIPTION
The restart schedules are massively out of date. They currently include schedules for servers that ShadowNode no longer hosts. This needs to be cleaned up and new servers added.